### PR TITLE
Include the response in a raised api exception

### DIFF
--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -222,12 +222,13 @@ class WithingsApi:
             '/'.join(url_parts),
             params=params
         )
-        response = json.loads(response.content.decode())
-        if response['status'] != 0:
+        parsed_response = json.loads(response.content.decode())
+        if parsed_response['status'] != 0:
             raise requests.exceptions.RequestException(
-                "Error code %s" % response['status']
+                "Error code %s" % parsed_response['status'],
+                response=response
             )
-        return response.get('body', None)
+        return parsed_response.get('body', None)
 
     def get_user(self):
         """Get user information."""


### PR DESCRIPTION
So that callers can inspect the status code.