### PR TITLE
Fix timezone handling.

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -310,7 +310,7 @@ def test_measure_get_activity(withings_api: WithingsApi) -> None:
         offset=0,
         activities=(
             MeasureGetActivityActivity(
-                date=arrow.get("2019-01-01").replace(tzinfo=TIMEZONE0),
+                date=arrow.get("2019-01-01").to(TIMEZONE0),
                 timezone=TIMEZONE0,
                 is_tracker=True,
                 deviceid="dev1",
@@ -333,7 +333,7 @@ def test_measure_get_activity(withings_api: WithingsApi) -> None:
                 hr_zone_3=116,
             ),
             MeasureGetActivityActivity(
-                date=arrow.get("2019-01-02").replace(tzinfo=TIMEZONE1),
+                date=arrow.get("2019-01-02").to(TIMEZONE1),
                 timezone=TIMEZONE1,
                 is_tracker=False,
                 deviceid="dev2",
@@ -417,13 +417,13 @@ def test_measure_get_meas(withings_api: WithingsApi) -> None:
         more=False,
         offset=0,
         timezone=TIMEZONE0,
-        updatetime=arrow.get(1409596058).replace(tzinfo=TIMEZONE0),
+        updatetime=arrow.get(1409596058).to(TIMEZONE0),
         measuregrps=(
             MeasureGetMeasGroup(
                 attrib=MeasureGetMeasGroupAttrib.MANUAL_USER_DURING_ACCOUNT_CREATION,
                 category=MeasureGetMeasGroupCategory.REAL,
-                created=arrow.get(1111111111).replace(tzinfo=TIMEZONE0),
-                date=arrow.get("2019-01-01").replace(tzinfo=TIMEZONE0),
+                created=arrow.get(1111111111).to(TIMEZONE0),
+                date=arrow.get("2019-01-01").to(TIMEZONE0),
                 deviceid="dev1",
                 grpid=1,
                 measures=(
@@ -434,8 +434,8 @@ def test_measure_get_meas(withings_api: WithingsApi) -> None:
             MeasureGetMeasGroup(
                 attrib=MeasureGetMeasGroupAttrib.DEVICE_ENTRY_FOR_USER_AMBIGUOUS,
                 category=MeasureGetMeasGroupCategory.USER_OBJECTIVES,
-                created=arrow.get(2222222222).replace(tzinfo=TIMEZONE0),
-                date=arrow.get("2019-01-02").replace(tzinfo=TIMEZONE0),
+                created=arrow.get(2222222222).to(TIMEZONE0),
+                date=arrow.get("2019-01-02").to(TIMEZONE0),
                 deviceid="dev2",
                 grpid=2,
                 measures=(
@@ -590,11 +590,11 @@ def test_sleep_get_summary(withings_api: WithingsApi) -> None:
         offset=1,
         series=(
             GetSleepSummarySerie(
-                date=arrow.get("2018-10-30").replace(tzinfo=TIMEZONE0),
-                enddate=arrow.get(1540897020).replace(tzinfo=TIMEZONE0),
+                date=arrow.get("2018-10-30").to(TIMEZONE0),
+                enddate=arrow.get(1540897020).to(TIMEZONE0),
                 model=SleepModel.TRACKER,
-                modified=arrow.get(1540897246).replace(tzinfo=TIMEZONE0),
-                startdate=arrow.get(1540857420).replace(tzinfo=TIMEZONE0),
+                modified=arrow.get(1540897246).to(TIMEZONE0),
+                startdate=arrow.get(1540857420).to(TIMEZONE0),
                 timezone=TIMEZONE0,
                 data=GetSleepSummaryData(
                     breathing_disturbances_intensity=110,
@@ -617,11 +617,11 @@ def test_sleep_get_summary(withings_api: WithingsApi) -> None:
                 ),
             ),
             GetSleepSummarySerie(
-                date=arrow.get("2018-10-31").replace(tzinfo=TIMEZONE1),
-                enddate=arrow.get(1540973400).replace(tzinfo=TIMEZONE1),
+                date=arrow.get("2018-10-31").to(TIMEZONE1),
+                enddate=arrow.get(1540973400).to(TIMEZONE1),
                 model=SleepModel.TRACKER,
-                modified=arrow.get(1541020749).replace(tzinfo=TIMEZONE1),
-                startdate=arrow.get(1540944960).replace(tzinfo=TIMEZONE1),
+                modified=arrow.get(1541020749).to(TIMEZONE1),
+                startdate=arrow.get(1540944960).to(TIMEZONE1),
                 timezone=TIMEZONE1,
                 data=GetSleepSummaryData(
                     breathing_disturbances_intensity=210,

--- a/withings_api/common.py
+++ b/withings_api/common.py
@@ -625,11 +625,11 @@ def new_get_sleep_summary_serie(data: dict) -> GetSleepSummarySerie:
     timezone: Final = timezone_or_raise(data.get("timezone"))
 
     return GetSleepSummarySerie(
-        date=arrow_or_raise(data.get("date")).replace(tzinfo=timezone),
-        enddate=arrow_or_raise(data.get("enddate")).replace(tzinfo=timezone),
+        date=arrow_or_raise(data.get("date")).to(timezone),
+        enddate=arrow_or_raise(data.get("enddate")).to(timezone),
         model=new_sleep_model(data.get("model")),
-        modified=arrow_or_raise(data.get("modified")).replace(tzinfo=timezone),
-        startdate=arrow_or_raise(data.get("startdate")).replace(tzinfo=timezone),
+        modified=arrow_or_raise(data.get("modified")).to(timezone),
+        startdate=arrow_or_raise(data.get("startdate")).to(timezone),
         timezone=timezone,
         data=new_get_sleep_summary_data(dict_or_raise(data.get("data"))),
     )
@@ -658,8 +658,8 @@ def new_measure_get_meas_group(data: dict, timezone: tzinfo) -> MeasureGetMeasGr
     return MeasureGetMeasGroup(
         grpid=int_or_raise(data.get("grpid")),
         attrib=new_measure_group_attrib(data.get("attrib")),
-        date=arrow_or_raise(data.get("date")).replace(tzinfo=timezone),
-        created=arrow_or_raise(data.get("created")).replace(tzinfo=timezone),
+        date=arrow_or_raise(data.get("date")).to(timezone),
+        created=arrow_or_raise(data.get("created")).to(timezone),
         category=new_measure_category(data.get("category")),
         deviceid=data.get("deviceid"),
         measures=_flexible_tuple_of(
@@ -700,7 +700,7 @@ def new_measure_get_meas_response(data: dict) -> MeasureGetMeasResponse:
         more=data.get("more"),
         offset=data.get("offset"),
         timezone=timezone,
-        updatetime=arrow_or_raise(data.get("updatetime")).replace(tzinfo=timezone),
+        updatetime=arrow_or_raise(data.get("updatetime")).to(timezone),
     )
 
 
@@ -709,7 +709,7 @@ def new_measure_get_activity_activity(data: dict) -> MeasureGetActivityActivity:
     timezone: Final = timezone_or_raise(data.get("timezone"))
 
     return MeasureGetActivityActivity(
-        date=arrow_or_raise(data.get("date")).replace(tzinfo=timezone),
+        date=arrow_or_raise(data.get("date")).to(timezone),
         timezone=timezone,
         deviceid=str_or_none(data.get("deviceid")),
         brand=int_or_raise(data.get("brand")),


### PR DESCRIPTION
Timestamps are always UTC, so using arrow's replace() method to alter the timezone information leads to incorrect results. Instead, the arrow objects should be converted to the right timezone, preserving the correct time.

Example: A measurement added via the HealthMate app this morning at 10:22 local time (Europe/Zurich) showed up in the measure_get_meas().measuregrps entry as 2020-06-06T08:22:53+02:00, rather than 2020-06-06T10:22:53+02:00.