### PR TITLE
Adding static args to refresh tokens.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "withings_api"
-version = "2.1.8"
+version = "2.1.9"
 description = "Library for the Withings API"
 
 license = "MIT"

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -442,6 +442,7 @@ class WithingsApi(AbstractWithingsApi):
             ),
             auto_refresh_url="%s/%s" % (WithingsAuth.URL, WithingsAuth.PATH_TOKEN),
             auto_refresh_kwargs={
+                "action": "requesttoken",
                 "client_id": credentials.client_id,
                 "client_secret": credentials.consumer_secret,
             },


### PR DESCRIPTION
Adding refresh to integration test.
Adding better fallback on integration test when previous credentials are expired.

fixes: #45