### PR TITLE
Fixes #62: Sleep data / arrow 1.0 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8,14 +8,15 @@ python-versions = "*"
 
 [[package]]
 name = "arrow"
-version = "0.17.0"
+version = "1.0.3"
 description = "Better dates & times for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 python-dateutil = ">=2.7.0"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "astroid"
@@ -606,7 +607,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6 || ^3.7"
-content-hash = "edffa4dbdf1fa371785240095bc53cbfafb1ce61675af5681ac1199e89447c50"
+content-hash = "9b96a2667b96a64e26f1bc8eda0a0c5e14d0af9e23c184acccac58f65aab9703"
 
 [metadata.files]
 appdirs = [
@@ -614,8 +615,8 @@ appdirs = [
     {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
 ]
 arrow = [
-    {file = "arrow-0.17.0-py2.py3-none-any.whl", hash = "sha256:e098abbd9af3665aea81bdd6c869e93af4feb078e98468dd351c383af187aac5"},
-    {file = "arrow-0.17.0.tar.gz", hash = "sha256:ff08d10cda1d36c68657d6ad20d74fbea493d980f8b2d45344e00d6ed2bf6ed4"},
+    {file = "arrow-1.0.3-py3-none-any.whl", hash = "sha256:3515630f11a15c61dcb4cdd245883270dd334c83f3e639824e65a4b79cc48543"},
+    {file = "arrow-1.0.3.tar.gz", hash = "sha256:399c9c8ae732270e1aa58ead835a79a40d7be8aa109c579898eb41029b5a231d"},
 ]
 astroid = [
     {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = "^3.6 || ^3.7"
-arrow = "0.17.0"
+arrow = ">=1.0.3"
 requests-oauth = ">=0.4.1"
 requests-oauthlib = ">=1.2"
 typing-extensions = ">=3.7.4.2"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -71,7 +71,7 @@ def test_maybe_update_credentials() -> None:
 
     creds1: Final = Credentials(
         access_token="my_access_token",
-        token_expiry=arrow.get("2020-01-01T00:00:00+07:00").timestamp,
+        token_expiry=arrow.get("2020-01-01T00:00:00+07:00").int_timestamp,
         token_type="Bearer",
         refresh_token="my_refresh_token",
         userid=1,
@@ -79,7 +79,7 @@ def test_maybe_update_credentials() -> None:
         consumer_secret="CONSUMER_SECRET",
     )
 
-    expires_in = creds1.token_expiry - arrow.utcnow().timestamp
+    expires_in = creds1.token_expiry - arrow.utcnow().int_timestamp
     creds2: Final = Credentials2(
         access_token="my_access_token",
         expires_in=expires_in,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -148,7 +148,7 @@ def test_authorize() -> None:
     assert creds.client_id == client_id
     assert creds.consumer_secret == consumer_secret
     assert creds.expires_in == 11
-    assert creds.token_expiry == arrow.utcnow().timestamp + 11
+    assert creds.token_expiry == arrow.utcnow().int_timestamp + 11
 
 
 @responses.activate

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -92,10 +92,10 @@ class AbstractWithingsApi:
     def measure_get_activity(
         self,
         data_fields: Iterable[GetActivityField] = GetActivityField,
-        startdateymd: Optional[DateType] = None,
-        enddateymd: Optional[DateType] = None,
+        startdateymd: Optional[DateType] = arrow.utcnow(),
+        enddateymd: Optional[DateType] = arrow.utcnow(),
         offset: Optional[int] = None,
-        lastupdate: Optional[DateType] = None,
+        lastupdate: Optional[DateType] = arrow.utcnow(),
     ) -> MeasureGetActivityResponse:
         """Get user created activities."""
         params: Final[ParamsType] = {}
@@ -132,10 +132,10 @@ class AbstractWithingsApi:
         self,
         meastype: Optional[MeasureType] = None,
         category: Optional[MeasureGetMeasGroupCategory] = None,
-        startdate: Optional[DateType] = None,
-        enddate: Optional[DateType] = None,
+        startdate: Optional[DateType] = arrow.utcnow(),
+        enddate: Optional[DateType] = arrow.utcnow(),
         offset: Optional[int] = None,
-        lastupdate: Optional[DateType] = None,
+        lastupdate: Optional[DateType] = arrow.utcnow(),
     ) -> MeasureGetMeasResponse:
         """Get measures."""
         params: Final[ParamsType] = {}
@@ -159,8 +159,8 @@ class AbstractWithingsApi:
     def sleep_get(
         self,
         data_fields: Iterable[GetSleepField],
-        startdate: Optional[DateType] = None,
-        enddate: Optional[DateType] = None,
+        startdate: Optional[DateType] = arrow.utcnow(),
+        enddate: Optional[DateType] = arrow.utcnow(),
     ) -> SleepGetResponse:
         """Get sleep data."""
         params: Final[ParamsType] = {}
@@ -182,10 +182,10 @@ class AbstractWithingsApi:
     def sleep_get_summary(
         self,
         data_fields: Iterable[GetSleepSummaryField],
-        startdateymd: Optional[DateType] = None,
-        enddateymd: Optional[DateType] = None,
+        startdateymd: Optional[DateType] = arrow.utcnow(),
+        enddateymd: Optional[DateType] = arrow.utcnow(),
         offset: Optional[int] = None,
-        lastupdate: Optional[DateType] = None,
+        lastupdate: Optional[DateType] = arrow.utcnow(),
     ) -> SleepGetSummaryResponse:
         """Get sleep summary."""
         params: Final[ParamsType] = {}
@@ -229,8 +229,8 @@ class AbstractWithingsApi:
 
     def heart_list(
         self,
-        startdate: Optional[DateType] = None,
-        enddate: Optional[DateType] = None,
+        startdate: Optional[DateType] = arrow.utcnow(),
+        enddate: Optional[DateType] = arrow.utcnow(),
         offset: Optional[int] = None,
     ) -> HeartListResponse:
         """Get heart list."""

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -145,7 +145,9 @@ class AbstractWithingsApi:
         update_params(
             params, "startdate", startdate, lambda val: arrow.get(val).int_timestamp
         )
-        update_params(params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp)
+        update_params(
+            params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp
+        )
         update_params(params, "offset", offset)
         update_params(
             params, "lastupdate", lastupdate, lambda val: arrow.get(val).int_timestamp
@@ -168,7 +170,9 @@ class AbstractWithingsApi:
         update_params(
             params, "startdate", startdate, lambda val: arrow.get(val).int_timestamp
         )
-        update_params(params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp)
+        update_params(
+            params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp
+        )
         update_params(
             params,
             "data_fields",

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -120,7 +120,7 @@ class AbstractWithingsApi:
             lambda fields: ",".join([field.value for field in fields]),
         )
         update_params(
-            params, "lastupdate", lastupdate, lambda val: arrow.get(val).timestamp
+            params, "lastupdate", lastupdate, lambda val: arrow.get(val).int_timestamp
         )
         update_params(params, "action", "getactivity")
 
@@ -143,12 +143,12 @@ class AbstractWithingsApi:
         update_params(params, "meastype", meastype, lambda val: val.value)
         update_params(params, "category", category, lambda val: val.value)
         update_params(
-            params, "startdate", startdate, lambda val: arrow.get(val).timestamp
+            params, "startdate", startdate, lambda val: arrow.get(val).int_timestamp
         )
-        update_params(params, "enddate", enddate, lambda val: arrow.get(val).timestamp)
+        update_params(params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp)
         update_params(params, "offset", offset)
         update_params(
-            params, "lastupdate", lastupdate, lambda val: arrow.get(val).timestamp
+            params, "lastupdate", lastupdate, lambda val: arrow.get(val).int_timestamp
         )
         update_params(params, "action", "getmeas")
 
@@ -166,9 +166,9 @@ class AbstractWithingsApi:
         params: Final[ParamsType] = {}
 
         update_params(
-            params, "startdate", startdate, lambda val: arrow.get(val).timestamp
+            params, "startdate", startdate, lambda val: arrow.get(val).int_timestamp
         )
-        update_params(params, "enddate", enddate, lambda val: arrow.get(val).timestamp)
+        update_params(params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp)
         update_params(
             params,
             "data_fields",
@@ -210,7 +210,7 @@ class AbstractWithingsApi:
         )
         update_params(params, "offset", offset)
         update_params(
-            params, "lastupdate", lastupdate, lambda val: arrow.get(val).timestamp
+            params, "lastupdate", lastupdate, lambda val: arrow.get(val).int_timestamp
         )
         update_params(params, "action", "getsummary")
 
@@ -237,10 +237,10 @@ class AbstractWithingsApi:
         params: Final[ParamsType] = {}
 
         update_params(
-            params, "startdate", startdate, lambda val: arrow.get(val).timestamp,
+            params, "startdate", startdate, lambda val: arrow.get(val).int_timestamp,
         )
         update_params(
-            params, "enddate", enddate, lambda val: arrow.get(val).timestamp,
+            params, "enddate", enddate, lambda val: arrow.get(val).int_timestamp,
         )
         update_params(params, "offset", offset)
         update_params(params, "action", "list")

--- a/withings_api/common.py
+++ b/withings_api/common.py
@@ -79,7 +79,7 @@ class TimeZone(tzlocal):
         raise TypeError("string or tzinfo required")
 
 
-class ArrowType(Arrow):  # type: ignore
+class ArrowType(Arrow):
     """Subclass of Arrow for parsing dates."""
 
     @classmethod

--- a/withings_api/common.py
+++ b/withings_api/common.py
@@ -605,7 +605,7 @@ class Credentials2(ConfiguredBaseModel):
     @property
     def token_expiry(self) -> int:
         """Get the token expiry."""
-        return cast(int, self.created.shift(seconds=self.expires_in).timestamp)
+        return cast(int, self.created.shift(seconds=self.expires_in).int_timestamp)
 
 
 CredentialsType = Union[Credentials, Credentials2]
@@ -624,7 +624,7 @@ def maybe_upgrade_credentials(value: CredentialsType) -> Credentials2:
         userid=creds.userid,
         client_id=creds.client_id,
         consumer_secret=creds.consumer_secret,
-        expires_in=creds.token_expiry - arrow.utcnow().timestamp,
+        expires_in=creds.token_expiry - arrow.utcnow().int_timestamp,
     )
 
 


### PR DESCRIPTION
Per my earlier PR #64, we're attempting to get the new version merged into [Home Assistant to fix #47329](https://github.com/home-assistant/core/issues/47329).

Under PR review, it came back they didn't like the pinning of arrow to a specific version number: https://github.com/home-assistant/core/pull/47975#issuecomment-800009350

I agree, I did that to avoid having to complete the arrow 1.0 migrations, but I should have just done the migrations from the start.

This PR update arrow to >= 1.0 and completes all the breaking change migrations they detailed here: https://github.com/arrow-py/arrow/issues/832

With the new arrow 1.0 dependency version, downstream users will be able to continue using this library with python 3.9 support and be able to keep their other dependencies, like arrow, up-to-date. Thank you!