### PR TITLE
Use OAuth2Session hooks to process reply

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -52,13 +52,16 @@ from .common import TIMEZONE0, TIMEZONE1, TIMEZONE_STR0, TIMEZONE_STR1
 _UNKNOWN_INT = 1234567
 _USERID: Final = 12345
 _FETCH_TOKEN_RESPONSE_BODY: Final = {
-    "access_token": "my_access_token",
-    "csrf_token": "CSRF_TOKEN",
-    "expires_in": 11,
-    "token_type": "Bearer",
-    "refresh_token": "my_refresh_token",
-    "scope": "user.metrics,user.activity",
-    "userid": _USERID,
+    "status": 0,
+    "body": {
+        "access_token": "my_access_token",
+        "csrf_token": "CSRF_TOKEN",
+        "expires_in": 11,
+        "token_type": "Bearer",
+        "refresh_token": "my_refresh_token",
+        "scope": "user.metrics,user.activity",
+        "userid": _USERID,
+    },
 }
 
 
@@ -109,7 +112,7 @@ def test_authorize() -> None:
 
     responses.add(
         method=responses.POST,
-        url="https://account.withings.com/oauth2/token",
+        url="https://wbsapi.withings.net/v2/oauth2",
         json=_FETCH_TOKEN_RESPONSE_BODY,
         status=200,
     )
@@ -169,20 +172,22 @@ def test_refresh_token() -> None:
 
     responses.add(
         method=responses.POST,
-        url=re.compile("https://account.withings.com/oauth2.*"),
+        url=re.compile("https://wbsapi.withings.net/v2/oauth2.*"),
         status=200,
         json=_FETCH_TOKEN_RESPONSE_BODY,
     )
     responses.add(
         method=responses.POST,
-        url=re.compile("https://account.withings.com/oauth2.*"),
+        url=re.compile("https://wbsapi.withings.net/v2/oauth2.*"),
         status=200,
         json={
-            "access_token": "my_access_token_refreshed",
-            "expires_in": 11,
-            "token_type": "Bearer",
-            "refresh_token": "my_refresh_token_refreshed",
-            "userid": _USERID,
+            "body": {
+                "access_token": "my_access_token_refreshed",
+                "expires_in": 11,
+                "token_type": "Bearer",
+                "refresh_token": "my_refresh_token_refreshed",
+                "userid": _USERID,
+            },
         },
     )
 

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -6,11 +6,14 @@ Withings Health API
 """
 from abc import abstractmethod
 import datetime
+import json
 from types import LambdaType
 from typing import Any, Callable, Dict, Iterable, Optional, Union, cast
 
 import arrow
+from oauthlib.common import to_unicode
 from oauthlib.oauth2 import WebApplicationClient
+from requests import Response
 from requests_oauthlib import OAuth2Session
 from typing_extensions import Final
 
@@ -52,6 +55,43 @@ def update_params(
         params[name] = new_value(current_value)
     else:
         params[name] = new_value or current_value
+
+
+def adjust_withings_token(response: Response) -> Response:
+    """Restructures token from withings response::
+
+        {
+            "status": [{integer} Withings API response status],
+            "body": {
+                "access_token": [{string} Your new access_token],
+                "expires_in": [{integer} Access token expiry delay in seconds],
+                "token_type": [{string] HTTP Authorization Header format: Bearer],
+                "scope": [{string} Scopes the user accepted],
+                "refresh_token": [{string} Your new refresh_token],
+                "userid": [{string} The Withings ID of the user]
+            }
+        }
+    """
+    try:
+        token = json.loads(response.text)
+    except Exception as ex:  # pylint: disable=broad-except
+        # If there was exception, just return unmodified response
+        print(ex)
+        return response
+    status = token.pop("status", 0)
+    if status:
+        # Set the error to the status
+        token["error"] = 0
+    body = token.pop("body", None)
+    if body:
+        # Put body content at root level
+        token.update(body)
+    print(token)
+    # pylint: disable=protected-access
+    response._content = to_unicode(json.dumps(token)).encode("UTF-8")
+    print(response._content)
+
+    return response
 
 
 class AbstractWithingsApi:
@@ -357,13 +397,19 @@ class WithingsAuth:
             redirect_uri=self._callback_uri,
             scope=",".join((scope.value for scope in self._scope)),
         )
+        self._session.register_compliance_hook(
+            "access_token_response", adjust_withings_token
+        )
+        self._session.register_compliance_hook(
+            "refresh_token_response", adjust_withings_token
+        )
 
     def get_authorize_url(self) -> str:
         """Generate the authorize url."""
         url: Final = str(
-            self._session.authorization_url("%s/%s" % (WithingsAuth.URL, self.PATH_AUTHORIZE))[
-                0
-            ]
+            self._session.authorization_url(
+                "%s/%s" % (WithingsAuth.URL, self.PATH_AUTHORIZE)
+            )[0]
         )
 
         if self._mode:
@@ -382,7 +428,7 @@ class WithingsAuth:
 
         return Credentials2(
             **{
-                **response["body"],
+                **response,
                 **dict(
                     client_id=self._client_id, consumer_secret=self._consumer_secret
                 ),
@@ -442,6 +488,12 @@ class WithingsApi(AbstractWithingsApi):
             },
             token_updater=self._update_token,
         )
+        self._client.register_compliance_hook(
+            "access_token_response", adjust_withings_token
+        )
+        self._client.register_compliance_hook(
+            "refresh_token_response", adjust_withings_token
+        )
 
     def _blank_refresh_cb(self, creds: Credentials2) -> None:
         """The default callback which does nothing."""
@@ -455,7 +507,7 @@ class WithingsApi(AbstractWithingsApi):
         token_dict: Final = self._client.refresh_token(
             token_url=self._client.auto_refresh_url
         )
-        self._update_token(token=token_dict["body"])
+        self._update_token(token=token_dict)
 
     def _update_token(self, token: Dict[str, Union[str, int]]) -> None:
         """Set the oauth token."""

--- a/withings_api/__init__.py
+++ b/withings_api/__init__.py
@@ -74,9 +74,8 @@ def adjust_withings_token(response: Response) -> Response:
     """
     try:
         token = json.loads(response.text)
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         # If there was exception, just return unmodified response
-        print(ex)
         return response
     status = token.pop("status", 0)
     if status:
@@ -86,10 +85,8 @@ def adjust_withings_token(response: Response) -> Response:
     if body:
         # Put body content at root level
         token.update(body)
-    print(token)
     # pylint: disable=protected-access
     response._content = to_unicode(json.dumps(token)).encode("UTF-8")
-    print(response._content)
 
     return response
 
@@ -424,6 +421,7 @@ class WithingsAuth:
             code=code,
             client_secret=self._consumer_secret,
             include_client_id=True,
+            action="requesttoken",
         )
 
         return Credentials2(


### PR DESCRIPTION
Hi @vangorra , the changes in oauth2 endpoint on Withings side are much bigger and incompatible out of the box with `OAuth2Session` and `oauthlib`. 

There is a need to add `access_token_response` and `refresh_token_response` hooks to modify response content and make it understandable by `oauthlib`.

For reference, the same logic is applied for [other oauth2 services (fitbit, linked-in or mailchimp)](https://github.com/search?q=register_compliance_hook&type=Code)
