### PR TITLE
ScanWatch ECG return empty reponses

### DIFF
--- a/withings_api/common.py
+++ b/withings_api/common.py
@@ -558,9 +558,9 @@ class HeartBloodPressure(ConfiguredBaseModel):
 class HeartListSerie(ConfiguredBaseModel):
     """HeartListSerie"""
 
-    ecg: HeartListECG
+    ecg: Optional[HeartListECG] = None
 
-    heart_rate: int
+    heart_rate: Optional[int] = None
     timestamp: ArrowType
     model: HeartModel
 


### PR DESCRIPTION
The ScanWatch records also the failed ECG assessment, in that case, a record is still created. However, no data can be found for ecg and hear_rate. It failed the validation step.